### PR TITLE
refactor: replace ansicolor gem with rainbow gem to avoid namespace collisions

### DIFF
--- a/lib/pact/matchers/embedded_diff_formatter.rb
+++ b/lib/pact/matchers/embedded_diff_formatter.rb
@@ -1,12 +1,11 @@
 require 'pact/shared/active_support_support'
-require 'term/ansicolor'
+require 'rainbow'
 
 module Pact
   module Matchers
     class EmbeddedDiffFormatter
 
       include Pact::ActiveSupportSupport
-      C = ::Term::ANSIColor
 
 
       EXPECTED = /"EXPECTED([A-Z_]*)":/
@@ -53,7 +52,7 @@ module Pact
       end
 
       def coloured_key match, colour
-        '"' + C.color(colour, match.downcase.gsub(/^"|":$/,'')) + '":'
+        '"' + Rainbow(match.downcase.gsub(/^"|":$/,'')).color(colour) + '":'
       end
 
     end

--- a/lib/pact/support/version.rb
+++ b/lib/pact/support/version.rb
@@ -1,5 +1,5 @@
 module Pact
   module Support
-    VERSION = "1.17.0"
+    VERSION = "1.17.1"
   end
 end

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -15,12 +15,12 @@ namespace :pact do
 
   desc "Verifies the pact at the given URI against this service provider."
   task 'verify:at', :pact_uri do | t, args |
-    require 'term/ansicolor'
+    require 'rainbow'
     require 'pact/tasks/task_helper'
 
     include Pact::TaskHelper
 
-    abort(::Term::ANSIColor.red("Please provide a pact URI. eg. rake pact:verify:at[../my-consumer/spec/pacts/my_consumer-my_provider.json]")) unless args[:pact_uri]
+    abort(Rainbow("Please provide a pact URI. eg. rake pact:verify:at[../my-consumer/spec/pacts/my_consumer-my_provider.json]").red) unless args[:pact_uri]
     handle_verification_failure do
       execute_pact_verify args[:pact_uri]
     end

--- a/pact-support.gemspec
+++ b/pact-support.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib CHANGELOG.md LICENSE.txt README.md`.split($RS)
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "term-ansicolor", "~> 1.0"
+  spec.add_runtime_dependency "rainbow", "~> 3.1.1"
   spec.add_runtime_dependency "awesome_print", "~> 1.9"
   spec.add_runtime_dependency "diff-lcs", "~> 1.4"
   spec.add_runtime_dependency "expgen", "~> 0.1"

--- a/spec/lib/pact/matchers/embedded_diff_formatter_spec.rb
+++ b/spec/lib/pact/matchers/embedded_diff_formatter_spec.rb
@@ -17,8 +17,8 @@ module Pact
       subject { EmbeddedDiffFormatter.call(diff, options) }
 
       let(:options) { { colour: colour }}
-      let(:expected_coloured) { '"' + ::Term::ANSIColor.red("expected_type") + '":'}
-      let(:actual_coloured) { '"' + ::Term::ANSIColor.green("actual_type") + '":'}
+      let(:expected_coloured) { '"' + Rainbow("expected_type").red + '":'}
+      let(:actual_coloured) { '"' + Rainbow("actual_type").green + '":'}
 
       describe ".call" do
 


### PR DESCRIPTION
The term-ansicolor gem injects a global Term module that has a high probability of naming collision for other common class names. This PR replaces that gem with the rainbow gem to avoid this issue.